### PR TITLE
Add support for issue_comment event trigger

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34923,10 +34923,46 @@ const run = async () => {
       _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("skip-if-not-in-project") === "true";
 
     const octokit = _actions_github__WEBPACK_IMPORTED_MODULE_1__.getOctokit(token);
+
     const issue = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.issue;
+    if (!issue || !issue.node_id) {
+      throw new Error("Invalid or missing issue object");
+    }
+
+    const eventName = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.eventName;
     const action = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.action;
 
     const projectData = await getProjectData(octokit, projectUrl);
+
+    if (eventName === "issue_comment") {
+      if (action === "created") {
+        // a comment was created on an issue
+        const hasTargetLabel = issue.labels.some((label) =>
+          TARGET_LABELS.includes(label.name)
+        );
+        if (hasTargetLabel) {
+          // Proceed as if the label was added to the issue
+          await processIssueItem(
+            octokit,
+            projectData,
+            issue,
+            TARGET_COLUMN,
+            IGNORED_COLUMNS,
+            SKIP_IF_NOT_IN_PROJECT
+          );
+        } else {
+          // Proceed as if the label was removed from the issue
+          await moveIssueToDefaultColumn(
+            octokit,
+            projectData,
+            issue,
+            DEFAULT_COLUMN,
+            IGNORED_COLUMNS
+          );
+        }
+        return;
+      }
+    }
 
     if (action === "labeled") {
       await handleLabeledEvent(
@@ -34953,7 +34989,7 @@ const run = async () => {
       return;
     }
 
-    console.log(`No action taken for ${action} event.`);
+    console.log(`No action taken for ${eventName}/${action} event.`);
   } catch (error) {
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`Error processing issue: ${error.message}`);
   }

--- a/index.js
+++ b/index.js
@@ -401,7 +401,12 @@ const run = async () => {
       core.getInput("skip-if-not-in-project") === "true";
 
     const octokit = github.getOctokit(token);
+
     const issue = github.context.payload.issue;
+    if (!issue || !issue.node_id) {
+      throw new Error("Invalid or missing issue object");
+    }
+
     const action = github.context.payload.action;
 
     const projectData = await getProjectData(octokit, projectUrl);

--- a/index.js
+++ b/index.js
@@ -407,9 +407,40 @@ const run = async () => {
       throw new Error("Invalid or missing issue object");
     }
 
+    const eventName = github.context.eventName;
     const action = github.context.payload.action;
 
     const projectData = await getProjectData(octokit, projectUrl);
+
+    if (eventName === "issue_comment") {
+      if (action === "created") {
+        // a comment was created on an issue
+        const hasTargetLabel = issue.labels.some((label) =>
+          TARGET_LABELS.includes(label.name)
+        );
+        if (hasTargetLabel) {
+          // Proceed as if the label was added to the issue
+          await processIssueItem(
+            octokit,
+            projectData,
+            issue,
+            TARGET_COLUMN,
+            IGNORED_COLUMNS,
+            SKIP_IF_NOT_IN_PROJECT
+          );
+        } else {
+          // Proceed as if the label was removed from the issue
+          await moveIssueToDefaultColumn(
+            octokit,
+            projectData,
+            issue,
+            DEFAULT_COLUMN,
+            IGNORED_COLUMNS
+          );
+        }
+        return;
+      }
+    }
 
     if (action === "labeled") {
       await handleLabeledEvent(
@@ -436,7 +467,7 @@ const run = async () => {
       return;
     }
 
-    console.log(`No action taken for ${action} event.`);
+    console.log(`No action taken for ${eventName} ${action} event.`);
   } catch (error) {
     core.setFailed(`Error processing issue: ${error.message}`);
   }

--- a/index.js
+++ b/index.js
@@ -467,7 +467,7 @@ const run = async () => {
       return;
     }
 
-    console.log(`No action taken for ${eventName} ${action} event.`);
+    console.log(`No action taken for ${eventName}/${action} event.`);
   } catch (error) {
     core.setFailed(`Error processing issue: ${error.message}`);
   }


### PR DESCRIPTION
This adds support for other event triggers

```yaml
on:
  issue_comment:
    types: [created]
```

Refs https://github.com/m7kvqbe1/github-action-move-issues/pull/28#issuecomment-2422181526

---

Note: Future work:

```yaml
on:
  schedule:
    - cron: 4 12 * * *
  workflow_dispatch:
```